### PR TITLE
Make the debugger log alert text more human-readable

### DIFF
--- a/src/commands/debugger/logs/list.js
+++ b/src/commands/debugger/logs/list.js
@@ -2,6 +2,7 @@ const { flags } = require('@oclif/command');
 const { TwilioClientCommand } = require('@twilio/cli-core').baseCommands;
 const { TwilioCliError } = require('@twilio/cli-core').services.error;
 const { sleep } = require('@twilio/cli-core').services.JSUtils;
+const querystring = require('querystring');
 
 const STREAMING_DELAY_IN_SECONDS = 1;
 const STREAMING_HISTORY_IN_MINUTES = 5;
@@ -75,8 +76,23 @@ class DebuggerLogsList extends TwilioClientCommand {
 
   outputLogEvents(logEvents) {
     if (logEvents.length > 0) {
+      // Provide a human readable error message
+      logEvents = logEvents.map(e => {
+        return Object.assign({}, e, {
+          alertText: this.formatAlertText(e.alertText)
+        });
+      });
       this.output(logEvents, this.flags.properties, { showHeaders: this.showHeaders });
       this.showHeaders = false;
+    }
+  }
+
+  formatAlertText(text) {
+    try {
+      const data = querystring.parse(text);
+      return data.Msg || text;
+    } catch (e) {
+      return text;
     }
   }
 }

--- a/src/commands/debugger/logs/list.js
+++ b/src/commands/debugger/logs/list.js
@@ -76,11 +76,8 @@ class DebuggerLogsList extends TwilioClientCommand {
 
   outputLogEvents(logEvents) {
     if (logEvents.length > 0) {
-      // Provide a human readable error message
-      logEvents = logEvents.map(e => {
-        return Object.assign({}, e, {
-          alertText: this.formatAlertText(e.alertText)
-        });
+      logEvents.forEach(e => {
+        e.alertText = this.formatAlertText(e.alertText);
       });
       this.output(logEvents, this.flags.properties, { showHeaders: this.showHeaders });
       this.showHeaders = false;
@@ -90,7 +87,7 @@ class DebuggerLogsList extends TwilioClientCommand {
   formatAlertText(text) {
     try {
       const data = querystring.parse(text);
-      return data.Msg || text;
+      return data.parserMessage || data.Msg || text;
     } catch (e) {
       return text;
     }

--- a/test/commands/debugger/logs/list.test.js
+++ b/test/commands/debugger/logs/list.test.js
@@ -18,6 +18,14 @@ const WARN_LOG = {
   alert_text: 'How do you do!?',
   date_created: '1969-02-24T20:40:30Z'
 };
+
+const ERROR_LOG = {
+  sid: 'NO22222222222222222222222222222222',
+  log_level: 'error',
+  error_code: '22222',
+  alert_text: 'sourceComponent=14100&httpResponse=502&url=https%3A%2F%2Fdemo.stwilio.com%2Fwelcome%2Fsms%2Freply%2F&ErrorCode=11210&LogLevel=ERROR&Msg=HTTP+bad+host+name&EmailNotification=false',
+  date_created: '1969-02-24T20:40:30Z'
+};
 /* eslint-enable camelcase */
 
 const testConfig = test
@@ -39,6 +47,11 @@ describe('debugger:logs:list', () => {
     testHelper([], 200, { alerts: [INFO_LOG] })
       .it('prints alert/log events', ctx => {
         expect(ctx.stdout).to.contain(INFO_LOG.alert_text);
+      });
+
+    testHelper([], 200, { alerts: [ERROR_LOG] })
+      .it('prints errors', ctx => {
+        expect(ctx.stdout).to.contain('HTTP bad host name');
       });
 
     testHelper([


### PR DESCRIPTION
When listing debugger logs, display the error message in a human readable format. I'm using the same strategy as https://github.com/twilio-labs/plugin-watch

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
