### PR TITLE
fix: Minor Change to README (fix 404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ DESCRIPTION
   us know here: https://twil.io/twilio-cli-feedback
 ```
 
-_See code: [src/commands/debugger/logs/list.js](https://github.com/twilio/plugin-debugger/blob/master/src/commands/debugger/logs/list.js)_
+_See code: [src/commands/debugger/logs/list.js](https://github.com/twilio/plugin-debugger/blob/1.1.9/src/commands/debugger/logs/list.js)_
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ DESCRIPTION
   us know here: https://twil.io/twilio-cli-feedback
 ```
 
-_See code: [src/commands/debugger/logs/list.js](https://github.com/twilio/plugin-debugger/blob/v1.1.9/src/commands/debugger/logs/list.js)_
+_See code: [src/commands/debugger/logs/list.js](https://github.com/twilio/plugin-debugger/blob/master/src/commands/debugger/logs/list.js)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "name": "debugger",
     "commands": "./src/commands",
     "bin": "twilio",
+    "repositoryPrefix": "<%- repo %>/blob/<%- version %>/<%- commandPath %>",
     "devPlugins": [
       "@oclif/plugin-help"
     ],


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Minor fix to the url in README.

New URL:
- https://github.com/twilio/plugin-debugger/blob/1.1.9/src/commands/debugger/logs/list.js

Prior URL:
- https://github.com/twilio/plugin-debugger/blob/v1.1.9/src/commands/debugger/logs/list.js

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
